### PR TITLE
remove the unused and deprecated `multilingual` field from `book.toml`

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["Tyson Wu"]
 language = "en"
-multilingual = false
 src = "src"
 title = "昨日 Sakubi: Yesterday's Grammar Guide"
 


### PR DESCRIPTION
See https://github.com/szabgab/public-mdbooks/issues/10